### PR TITLE
Adding http urls to the array of tlds to strip out

### DIFF
--- a/facebook-page-feed-graph-api.php
+++ b/facebook-page-feed-graph-api.php
@@ -366,7 +366,7 @@ class cameronjonesweb_facebook_page_plugin {
 
 class cameronjonesweb_facebook_page_plugin_widget extends WP_Widget {
 	
-	private $facebookURLs = array('https://www.facebook.com/', 'https://facebook.com/', 'www.facebook.com/', 'facebook.com/');
+	private $facebookURLs = array( 'https://www.facebook.com/', 'https://facebook.com/', 'www.facebook.com/', 'facebook.com/', 'http://facebook.com/', 'http://www.facebook.com/' );
 	private $settings;
 	
 	function __construct() {


### PR DESCRIPTION
Fixes this issue https://wordpress.org/support/topic/feed-has-disappeared-2/