### PR TITLE
Fixing generator using wrong attribute name for language

### DIFF
--- a/js/facebook-page-plugin-admin.js
+++ b/js/facebook-page-plugin-admin.js
@@ -65,7 +65,7 @@
                 }
 				var $lang = $('#fbpp-lang').val();
 				if($lang.length > 0){
-                    $shortcode += 'lang="' + $lang + '" ';
+                    $shortcode += 'language="' + $lang + '" ';
                 }
                 $shortcode += ']';
                 $('#facebook-page-plugin-shortcode-generator-output').val($shortcode);


### PR DESCRIPTION
Ref: https://wordpress.org/support/topic/language-setting-site-language-not-working/